### PR TITLE
removed source for guest image

### DIFF
--- a/manuscript-manager/components/profile/profileIcon.tsx
+++ b/manuscript-manager/components/profile/profileIcon.tsx
@@ -20,9 +20,9 @@ import { useSession, signIn, signOut } from "next-auth/react";
 export default function ProfileAvatarDropdown() {
   const { data: session } = useSession();
 
-  let name = session?.user?.name || "no name";
-  let image = session?.user?.image || "no image";
-  let email = session?.user?.email || "no email";
+  let name: string = session?.user?.name || "no name";
+  let image: string = session?.user?.image || "";
+  let email: string = session?.user?.email || "no email";
 
   if (session) {
     return (
@@ -71,7 +71,7 @@ export default function ProfileAvatarDropdown() {
         <Menu>
           <MenuButton>
             {" "}
-            <Avatar name={"Guest"} src={"Guest Image"} />
+            <Avatar name={"Guest"} />
           </MenuButton>
           <MenuList>
             <MenuItem onClick={() => signIn()}>Sign In</MenuItem>


### PR DESCRIPTION
This solves the issue of 404 not found for guest image. There is never a time when the avatar component needs a src for an image, as we are relying on the default. It throws an error because the src was not a path for an image, but instead just a string. Removing the string does not change the functionality, it just removes the error.

I also changed the string in case the user does not have an image loaded, but this is unlikely to happen at this stage, as the github default image should be present for the user.

Made types explicit for profile variables.