### PR TITLE
Feat/delete prompt

### DIFF
--- a/manuscript-manager/components/manuscript/deleteManuscriptButton.tsx
+++ b/manuscript-manager/components/manuscript/deleteManuscriptButton.tsx
@@ -2,6 +2,8 @@
 // so manuscript will correspond with it's own delete button
 
 import { ManuscriptType } from "@/types/manuscripts";
+import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Button, useDisclosure } from "@chakra-ui/react";
+import { RefObject, useRef } from "react";
 
 interface DeleteManuscriptButtonProps {
   manuscript: ManuscriptType;
@@ -14,6 +16,11 @@ export default function DeleteManuscriptButton({
   manuscriptsInState,
   setManuscriptsInState,
 }: DeleteManuscriptButtonProps) {
+
+  //Hooks for alert
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<any>() //Could not figure out typing. leastDestructiveRef requires RefObject<FocusableElement>. RefObject comes from react, but I could not find FocusableElement as a type in what we have. 
+
   const deleteManuscript = async () => {
     // delete manuscript from state
     if (manuscriptsInState) {
@@ -46,7 +53,40 @@ export default function DeleteManuscriptButton({
     } catch (error) {
       console.error("Error:", error);
     }
+    onClose();
   };
 
-  return <button onClick={deleteManuscript}>Delete</button>;
+  return <>
+  
+  <button onClick={onOpen}>Delete</button>
+
+{/* 
+  Below is the confirmation popup for the delete button
+*/}
+  <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
+  <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize='lg' fontWeight='bold'>
+              Delete Manuscript
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              Are you sure? This cannot be undone.
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                Cancel
+              </Button>
+              <Button colorScheme='red' onClick={deleteManuscript} ml={3}>
+                Delete
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+  </AlertDialog>
+
+
+  
+  </>;
 }

--- a/manuscript-manager/components/manuscript/deleteManuscriptButton.tsx
+++ b/manuscript-manager/components/manuscript/deleteManuscriptButton.tsx
@@ -2,7 +2,7 @@
 // so manuscript will correspond with it's own delete button
 
 import { ManuscriptType } from "@/types/manuscripts";
-import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Button, useDisclosure } from "@chakra-ui/react";
+import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Button, useDisclosure, useToast } from "@chakra-ui/react";
 import { RefObject, useRef } from "react";
 
 interface DeleteManuscriptButtonProps {
@@ -20,7 +20,8 @@ export default function DeleteManuscriptButton({
   //Hooks for alert
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef<any>() //Could not figure out typing. leastDestructiveRef requires RefObject<FocusableElement>. RefObject comes from react, but I could not find FocusableElement as a type in what we have. 
-
+  const toast = useToast();
+  
   const deleteManuscript = async () => {
     // delete manuscript from state
     if (manuscriptsInState) {
@@ -45,10 +46,24 @@ export default function DeleteManuscriptButton({
       const json = await response.json();
 
       if (!response.ok) {
-        console.log("There was an error deleting the manuscript.");
+        console.log("There was an error deleting the manuscript.")
+        toast({
+          title: "Error",
+          description: "There was an error deleting the manuscript.",
+          status: "error",
+          duration: 4000,
+          isClosable: true,
+        })
       }
       if (response.ok) {
         console.log("Response:", json);
+        toast({
+          title: "Manuscript Deleted.",
+          description: "Manuscript has been successfully deleted.",
+          status: "success",
+          duration: 2000,
+          isClosable: true,
+      })
       }
     } catch (error) {
       console.error("Error:", error);


### PR DESCRIPTION
Added a confirmation prompt for the delete manuscript button in the table. Also added toast for good/bad responses, but no toast for caught errors. 

I could not figure out the type for useRef for it to work with the chakra UI element, so it is currently set to any. Will have to change this later. 

Can you please have a glance over to make sure that this is working fine/no glaring issues :) 