### PR TITLE
Bug/table showing other user data

### DIFF
--- a/manuscript-manager/components/table/table.tsx
+++ b/manuscript-manager/components/table/table.tsx
@@ -58,8 +58,8 @@ export default function ManuscriptTable({
 
             return (
               <Tr key={index}>
-                <Td>{date.toDateString()}</Td>
-                <Td>{manuscript.user}</Td>
+                {/* <Td>{date.toDateString()}</Td>
+                <Td>{manuscript.user}</Td> */}
                 <Td>{manuscript.manuscriptID}</Td>
                 <Td>{manuscript.wordCount}</Td>
                 <Td>{manuscript.latex ? tick : undefined}</Td>

--- a/manuscript-manager/components/table/table.tsx
+++ b/manuscript-manager/components/table/table.tsx
@@ -20,7 +20,7 @@ interface ManuscriptTableProps {
   data: ManuscriptType[];
   caption?: string;
   setManuscriptToUpdate: (manuscript: ManuscriptType) => void;
-  
+
   setManuscriptsInState: (manuscript: ManuscriptType[]) => void;
 }
 
@@ -29,7 +29,7 @@ export default function ManuscriptTable({
   data,
   caption,
   setManuscriptToUpdate,
-  
+
   setManuscriptsInState,
 }: ManuscriptTableProps) {
   let tick: string = "✓";
@@ -58,8 +58,8 @@ export default function ManuscriptTable({
 
             return (
               <Tr key={index}>
-                {/* <Td>{date.toDateString()}</Td>
-                <Td>{manuscript.user}</Td> */}
+                <Td>{date.toDateString()}</Td>
+                <Td>{manuscript.user}</Td>
                 <Td>{manuscript.manuscriptID}</Td>
                 <Td>{manuscript.wordCount}</Td>
                 <Td>{manuscript.latex ? tick : undefined}</Td>

--- a/manuscript-manager/pages/api/manuscripts/getTodaysManuscripts.ts
+++ b/manuscript-manager/pages/api/manuscripts/getTodaysManuscripts.ts
@@ -5,16 +5,17 @@ export default async function getTodaysManuscripts(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  // get yesterday's date for filtering purposes
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
+  // get today's date for filtering purposes
+  let today = new Date();
+  today.setUTCHours(0, 0, 0, 0); // sets time to 00:00:00.000 UTC
   try {
     const client = await clientPromise; // clientPromise is a function that gets the instance of the MongoDB database
     const db = client.db("test"); // specifies which collection in the database we are accessing
 
+    // gets manuscripts with a date greater than or equal to today, midnight (UTC)
     const data = await db
       .collection("manuscripts")
-      .find({ date: { $gt: yesterday.toISOString() } })
+      .find({ date: { $gte: today.toISOString() } })
       .sort({ date: -1 })
       .toArray();
     res.json(data);

--- a/manuscript-manager/pages/api/manuscripts/getTodaysManuscripts.ts
+++ b/manuscript-manager/pages/api/manuscripts/getTodaysManuscripts.ts
@@ -1,5 +1,8 @@
 import clientPromise from "../../../lib/mongodb";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import UserType from "@/types/user";
 
 export default async function getTodaysManuscripts(
   req: NextApiRequest,
@@ -8,14 +11,36 @@ export default async function getTodaysManuscripts(
   // get today's date for filtering purposes
   let today = new Date();
   today.setUTCHours(0, 0, 0, 0); // sets time to 00:00:00.000 UTC
-  try {
-    const client = await clientPromise; // clientPromise is a function that gets the instance of the MongoDB database
-    const db = client.db("test"); // specifies which collection in the database we are accessing
 
-    // gets manuscripts with a date greater than or equal to today, midnight (UTC)
+  try {
+    const client = await clientPromise;
+    const db = client.db("test");
+
+    // get user data
+    const session = await getServerSession(req, res, authOptions);
+
+    let user: UserType = {
+      name: "guest",
+      email: "guest@email.com",
+      payRate: Number(process.env.PAYRATE_DEFAULT),
+    };
+
+    if (session) {
+      // Find the document with the same email
+      const email = session?.user?.email;
+      const userData = await db.collection("users").findOne({ email });
+
+      user = {
+        name: userData?.name,
+        email: userData?.email,
+        payRate: userData?.payRate ? userData.payRate : null,
+      };
+    }
+
+    // gets manuscripts with a date greater than or equal to today, midnight (UTC), for the current user
     const data = await db
       .collection("manuscripts")
-      .find({ date: { $gte: today.toISOString() } })
+      .find({ date: { $gte: today.toISOString() }, user: user.name })
       .sort({ date: -1 })
       .toArray();
     res.json(data);


### PR DESCRIPTION
Table should now be correctly filtering for the current user and date when a manuscript is submitted or updated.

To test this, you can uncomment date and user from the table columns to see if another user/date is being displayed when it shouldn't be.