### PR TITLE
fixed NaNbug AtAGlance

### DIFF
--- a/manuscript-manager/components/stats/summary.tsx
+++ b/manuscript-manager/components/stats/summary.tsx
@@ -16,7 +16,17 @@ interface SummaryProps {
 }
 
 function Summary({ statistic, label, lastStatistic }: SummaryProps) {
-  const percent: string = getPercentageChange(statistic, lastStatistic) + "%";
+  let num: number = getPercentageChange(statistic, lastStatistic)
+  let percent: string = num + "%";
+  let comparison: boolean = true;
+
+  //check whether NaN or infinite.
+  if(Number.isNaN(num) || !Number.isFinite(num)) {
+    percent = "No data to compare"
+    comparison = false;
+  }
+
+
 
   let name;
   let dollars;
@@ -49,9 +59,9 @@ function Summary({ statistic, label, lastStatistic }: SummaryProps) {
       </StatNumber>
       <StatHelpText>
         {percent}
-        <StatArrow
+        {comparison && <StatArrow
           type={statistic > lastStatistic ? "increase" : "decrease"}
-        ></StatArrow>
+        ></StatArrow>}
       </StatHelpText>
 
       <StatHelpText>


### PR DESCRIPTION
Summary component updated to conditionally render the percent comparison to avoid displaying NaN and infinity in cases where there were no data to compare. Will now display "no data to compare".